### PR TITLE
disable preview for loadContext

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -44,6 +44,11 @@ function saveContext() {
 
 function loadContext() {
     wakeUpContexts();
+    const options = {
+        preserveFocus: true,
+        preview: true,
+        viewColumn: vscode.ViewColumn.One
+    }
     let contextNames = Object.keys(contexts).filter((key) => key != 'fileName');
     vscode.window.showQuickPick(contextNames).then(contextName => {
         let editorsToOpen = contexts[contextName];
@@ -51,7 +56,7 @@ function loadContext() {
             closeAllEditors().then(() => {
                 editorsToOpen.map(tab => {
                     vscode.workspace.openTextDocument(tab).then(document => {
-                        vscode.window.showTextDocument(document, vscode.ViewColumn.One, true).then(() => { }, () => { });
+                        vscode.window.showTextDocument(document, options).then(() => { }, () => { });
                     });
                 });
                 updateContextsStatusBarItem(contextName);


### PR DESCRIPTION
With preview enabled the loadContext method just cycle through the tabs and leave you with only the last one opened in the preview.